### PR TITLE
Typo fix in plugin config

### DIFF
--- a/SpringBatchGrailsPlugin.groovy
+++ b/SpringBatchGrailsPlugin.groovy
@@ -58,7 +58,7 @@ class SpringBatchGrailsPlugin {
         def dataSourceBean = conf.dataSource
         def loadRequired = loadRequiredSpringBatchBeans.clone()
         loadRequired.delegate = delegate
-        loadRequired(dataSourceBean, tablePrefix, conf.dataase)
+        loadRequired(dataSourceBean, tablePrefix, conf.database)
 
         def loadConfig = loadBatchConfig.clone()
         loadConfig.delegate = delegate


### PR DESCRIPTION
The plugin still works without this fix by getting the database type from the datasource metadata but this avoids getting the message "No database type set, using meta data indicating:" every run.
